### PR TITLE
Fix Midjourney API capitalization

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,4 @@
-Golang Midjourney Api [![License](https://img.shields.io/static/v1?label=license&message=GPL3.0&color=green)](https://github.com/hugoshao/go_midjourney-api/blob/main/LICENSE)
+Golang Midjourney API [![License](https://img.shields.io/static/v1?label=license&message=GPL3.0&color=green)](https://github.com/hugoshao/go_midjourney-api/blob/main/LICENSE)
 ---
 使用 Golang 实现代理Discord频道，Midjourney API调用。
 


### PR DESCRIPTION
## Summary
- fix capitalisation of API in README

## Testing
- `go vet ./...` *(fails: Forbidden due to missing network)*
- `go fmt ./...`

------
https://chatgpt.com/codex/tasks/task_e_685f604262d08320a5a866ca54fa7357